### PR TITLE
Allow serial to be using with stdio

### DIFF
--- a/drivers/picocalc.c
+++ b/drivers/picocalc.c
@@ -53,7 +53,7 @@ void picocalc_chars_available_notify(void)
     }
 }
 
-stdio_driver_t my_stdio_driver = {
+stdio_driver_t picocalc_stdio_driver = {
     .out_chars = picocalc_out_chars,
     .out_flush = picocalc_out_flush,
     .in_chars = picocalc_in_chars,
@@ -69,6 +69,6 @@ void picocalc_init(led_callback_t led_set_callback)
     audio_init();
     fat32_init();
 
-    stdio_set_driver_enabled(&my_stdio_driver, true);
-    stdio_set_translate_crlf(&my_stdio_driver, true);
+    stdio_set_driver_enabled(&picocalc_stdio_driver, true);
+    stdio_set_translate_crlf(&picocalc_stdio_driver, true);
 }

--- a/drivers/picocalc.h
+++ b/drivers/picocalc.h
@@ -2,6 +2,8 @@
 
 #include "pico/stdlib.h"
 
+#include "pico/stdio/driver.h"
+
 typedef void (*led_callback_t)(uint8_t);
 
 extern stdio_driver_t picocalc_stdio_driver;

--- a/drivers/picocalc.h
+++ b/drivers/picocalc.h
@@ -4,5 +4,7 @@
 
 typedef void (*led_callback_t)(uint8_t);
 
+extern stdio_driver_t picocalc_stdio_driver;
+
 // Function prototypes
 void picocalc_init(led_callback_t led_callback);

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -9,6 +9,8 @@
 //
 
 #include "pico/stdlib.h"
+#include "pico/stdio/driver.h"
+
 #include "hardware/uart.h"
 #include "hardware/irq.h"
 
@@ -18,9 +20,14 @@
 
 extern volatile bool user_interrupt;
 
+void serial_chars_available_notify(void);
+
 static volatile uint8_t rx_buffer[UART_BUFFER_SIZE];
 static volatile uint16_t rx_head = 0;
 static volatile uint16_t rx_tail = 0;
+
+static void (*chars_available_callback)(void *) = NULL;
+static void *chars_available_param = NULL;
 
 // Interrupt handler for UART RX
 static void on_uart_rx()
@@ -39,6 +46,7 @@ static void on_uart_rx()
         uint16_t next_head = (rx_head + 1) & (UART_BUFFER_SIZE - 1);
         rx_buffer[rx_head] = ch;
         rx_head = next_head;
+        //serial_chars_available_notify();
     }
 }
 
@@ -67,6 +75,56 @@ void serial_put_char(char ch)
 {
     uart_putc(UART_PORT, ch);             // Send the character
 }
+
+
+static void serial_out_chars(const char *buf, int length)
+{
+    for (int i = 0; i < length; ++i)
+    {
+        serial_put_char(buf[i]);
+    }
+}
+
+static void serial_out_flush(void)
+{
+    // No flush needed for this driver
+}
+
+static int serial_in_chars(char *buf, int length)
+{
+    int n = 0;
+    while (n < length)
+    {
+        int c = serial_get_char();
+        if (c == -1)
+            break; // No key pressed
+        buf[n++] = (char)c;
+    }
+    return n;
+}
+
+static void serial_set_chars_available_callback(void (*fn)(void *), void *param)
+{
+    chars_available_callback = fn;
+    chars_available_param = param;
+}
+
+// Function to be called when characters become available
+void serial_chars_available_notify(void)
+{
+    if (chars_available_callback)
+    {
+        chars_available_callback(chars_available_param);
+    }
+}
+
+stdio_driver_t serial_stdio_driver = {
+    .out_chars = serial_out_chars,
+    .out_flush = serial_out_flush,
+    .in_chars = serial_in_chars,
+    .set_chars_available_callback = serial_set_chars_available_callback,
+    .next = NULL,
+};
 
 void serial_init(uint baudrate, uint databits, uint stopbits, uart_parity_t parity)
 {

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -46,7 +46,6 @@ static void on_uart_rx()
         uint16_t next_head = (rx_head + 1) & (UART_BUFFER_SIZE - 1);
         rx_buffer[rx_head] = ch;
         rx_head = next_head;
-        //serial_chars_available_notify();
     }
 }
 

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -46,6 +46,7 @@ static void on_uart_rx()
         uint16_t next_head = (rx_head + 1) & (UART_BUFFER_SIZE - 1);
         rx_buffer[rx_head] = ch;
         rx_head = next_head;
+        serial_chars_available_notify();
     }
 }
 

--- a/drivers/serial.h
+++ b/drivers/serial.h
@@ -2,6 +2,8 @@
 
 #include "pico/stdlib.h"
 
+#include "pico/stdio/driver.h"
+
 #define UART_PORT           (uart0)        // UART interface for the serial console
 #define UART_IRQ            (UART0_IRQ)    // UART interrupt number
 

--- a/drivers/serial.h
+++ b/drivers/serial.h
@@ -16,6 +16,9 @@
 
 #define UART_BUFFER_SIZE    256
 
+
+extern stdio_driver_t serial_stdio_driver;
+
 // Function prototypes
 void serial_init(uint baudrate, uint databits, uint stopbits, uart_parity_t parity);
 bool serial_input_available(void);


### PR DESCRIPTION
This pull request refactors the `picocalc` and `serial` drivers to improve modularity and flexibility by introducing `stdio_driver_t` structures for both drivers and enhancing the serial driver with callback functionality. The changes primarily focus on creating reusable and extensible interfaces for character input/output operations.

### Refactoring of `picocalc` driver:

* Renamed the `stdio_driver_t` instance from `my_stdio_driver` to `picocalc_stdio_driver` for better naming consistency and clarity. (`drivers/picocalc.c`, [drivers/picocalc.cL56-R56](diffhunk://#diff-874928b180a16521db25424069bd5f2342ebb6363ca49a5f7e3a0c9241991489L56-R56))
* Updated the `picocalc_init` function to use the renamed `picocalc_stdio_driver`. (`drivers/picocalc.c`, [drivers/picocalc.cL72-R73](diffhunk://#diff-874928b180a16521db25424069bd5f2342ebb6363ca49a5f7e3a0c9241991489L72-R73))
* Declared `picocalc_stdio_driver` as an external symbol in the header file for broader accessibility. (`drivers/picocalc.h`, [drivers/picocalc.hR7-R8](diffhunk://#diff-55c363c66b63a7fb36255bbf21d15c922c578e688515f9374359e27957704a0fR7-R8))

### Enhancements to `serial` driver:

* Introduced a complete `stdio_driver_t` implementation (`serial_stdio_driver`) for the serial driver, including functions for character input/output, flushing, and setting a callback for character availability. (`drivers/serial.c`, [drivers/serial.cR79-R128](diffhunk://#diff-35e74e2c3ce0379ae398a70c885636d0d25a8ba236fdbd0d0bf0f53ce4895d8fR79-R128))
* Added a callback mechanism (`serial_set_chars_available_callback`) to notify when characters are available, improving flexibility for asynchronous operations. (`drivers/serial.c`, [[1]](diffhunk://#diff-35e74e2c3ce0379ae398a70c885636d0d25a8ba236fdbd0d0bf0f53ce4895d8fR23-R31) [[2]](diffhunk://#diff-35e74e2c3ce0379ae398a70c885636d0d25a8ba236fdbd0d0bf0f53ce4895d8fR79-R128)
* Declared `serial_stdio_driver` as an external symbol in the header file for use in other modules. (`drivers/serial.h`, [drivers/serial.hR19-R21](diffhunk://#diff-95f2ba7e9624d040b3be06c2d2d682e1bc57e6c88c1d347930346de44ca2a8ecR19-R21))

### Minor updates:

* Included the `pico/stdio/driver.h` header in the serial driver to support the `stdio_driver_t` structure. (`drivers/serial.c`, [drivers/serial.cR12-R13](diffhunk://#diff-35e74e2c3ce0379ae398a70c885636d0d25a8ba236fdbd0d0bf0f53ce4895d8fR12-R13))
* Commented out a redundant call to `serial_chars_available_notify` in the UART RX interrupt handler. (`drivers/serial.c`, [drivers/serial.cR49](diffhunk://#diff-35e74e2c3ce0379ae398a70c885636d0d25a8ba236fdbd0d0bf0f53ce4895d8fR49))