### PR TITLE
Support BIOS 1.4; add lcd_putstr()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(picocalc-text-starter
         )
 
 pico_set_program_name(picocalc-text-starter "picocalc-text-starter")
-pico_set_program_version(picocalc-text-starter "0.9")
+pico_set_program_version(picocalc-text-starter "0.10")
 
 
 # Generate PIO header
@@ -97,6 +97,7 @@ target_link_libraries(picocalc-text-starter
         pico_printf
         pico_float
         pico_status_led
+        pico_rand
         hardware_gpio
         hardware_i2c
         hardware_spi

--- a/commands.c
+++ b/commands.c
@@ -39,6 +39,7 @@ static const command_t commands[] = {
     {"more", sd_more, "Page through a file"},
     {"play", play, "Play a song"},
     {"pwd", sd_pwd, "Print working directory"},
+    {"reset", reset, "Reset the device"},
     {"rm", sd_rm, "Remove a file"},
     {"rmdir", sd_rmdir, "Remove a directory"},
     {"sdcard", sd_status, "Show SD card status"},
@@ -441,6 +442,13 @@ void width_set(const char *width)
 
     printf("Terminal width set to %s characters.\n", width);
 }
+
+void reset()
+{
+    printf("Resetting the device in one second...\n");
+    sb_reset(1);
+}
+
 //
 // SD Card Commands
 //

--- a/commands.h
+++ b/commands.h
@@ -24,6 +24,7 @@ void show_command_library(void);
 void test(void);
 void width(void);
 void width_set(const char *width_str);
+void reset();
 
 // SD card commands
 void sd_pwd(void);

--- a/docs/lcd.md
+++ b/docs/lcd.md
@@ -197,6 +197,19 @@ Draws a glyph at a location on the display.
 - c – glygh to draw (font offset)
 
 
+## lcd_putstr
+
+`void lcd_putstr(uint8_t column, uint8_t row, const char *s)`
+
+Draws a string of glyphs at a location on the display.
+
+### Parameters
+
+- column - horizontal location to draw
+- row – vertical location to draw
+- s – a pointer to the string of glyphs to draw (font offsets)
+
+
 ## lcd_move_cursor
 
 `void lcd_move_cursor(uint8_t column, uint8_t row)`

--- a/docs/southbridge.md
+++ b/docs/southbridge.md
@@ -8,6 +8,11 @@ The southbridge is the MPU (STM32F103R8T6) on the mainboard of the PicoCalc. Thi
 
 Read a key status and code from the keyboard as a 16-bit half-word. The upper byte is the key status, the lower byte is the key code. 
 
+## sb_read_keyboard_state
+
+`uint16_t sb_read_keyboard_state(void)`
+
+Read the current state of the keyboard. The value is the number of characters waiting in the FIFO. If bit 5 is set, it indicates that the CapsLK is set.
 
 ## sb_read_battery
 
@@ -49,3 +54,24 @@ Sets the keyboard backlight brightness.
 ### Parameters
 
 - brightness – a value between 0 (dark) and 255 (bright)
+
+
+## sb_is_power_off_supported
+
+`bool sb_is_power_off_supported(void)`
+
+Returns true if power off is supported, false otherwise.
+
+
+## sb_write_power_off_delay
+
+`void sb_write_power_off_delay(uint8_t delay_seconds)`
+
+Sets a power off delay with the power management unit. Not sure what this does.
+
+
+## sb_reset
+
+`void sb_reset(uint8_t delay_seconds)`
+
+Reset the PicoCalc after a delay.

--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -21,6 +21,7 @@
 #include "southbridge.h"
 
 extern volatile bool user_interrupt;
+extern volatile bool power_off_requested;
 keyboard_key_available_callback_t keyboard_key_available_callback = NULL;
 
 // Modifier key states
@@ -73,6 +74,10 @@ static bool on_keyboard_timer(repeating_timer_t *rt)
                 else if (key_code == KEY_BREAK)
                 {
                     user_interrupt = true; // set user interrupt flag
+                }
+                else if (key_code == KEY_POWER)
+                {
+                    power_off_requested = true; // set power off requested flag
                 }
                 else
                 {

--- a/drivers/keyboard.h
+++ b/drivers/keyboard.h
@@ -47,6 +47,7 @@
 #define KEY_F9              (0x89)
 #define KEY_F10             (0x90)
 
+#define KEY_POWER           (0x91)
 
 // Keyboard type-ahead buffer
 #define KBD_BUFFER_SIZE     (32)

--- a/drivers/lcd.h
+++ b/drivers/lcd.h
@@ -110,6 +110,7 @@ void lcd_scroll_down(void);
 
 // Character and cursor functions
 void lcd_putc(uint8_t column, uint8_t row, uint8_t c);
+void lcd_putstr(uint8_t column, uint8_t row, const char *str);
 void lcd_move_cursor(uint8_t x, uint8_t y);
 void lcd_draw_cursor(void);
 void lcd_erase_cursor(void);

--- a/drivers/southbridge.h
+++ b/drivers/southbridge.h
@@ -15,17 +15,18 @@
 
 
 // Keyboard register definitions
-#define SB_REG_VER         (0x01)      // fw version
-#define SB_REG_CFG         (0x02)      // config
-#define SB_REG_INT         (0x03)      // interrupt status
-#define SB_REG_KEY         (0x04)      // key status
-#define SB_REG_BKL         (0x05)      // backlight
-#define SB_REG_DEB         (0x06)      // debounce cfg
-#define SB_REG_FRQ         (0x07)      // poll freq cfg
-#define SB_REG_RST         (0x08)      // reset
-#define SB_REG_FIF         (0x09)      // fifo
-#define SB_REG_BK2         (0x0A)      // keyboard backlight
-#define SB_REG_BAT         (0x0b)      // battery
+//#define SB_REG_VER         (0x01)      // fw version
+//#define SB_REG_CFG         (0x02)      // config
+//#define SB_REG_INT         (0x03)      // interrupt status
+#define SB_REG_KEY         (0x04)      // *key status
+#define SB_REG_BKL         (0x05)      // *backlight
+//#define SB_REG_DEB         (0x06)      // debounce cfg
+//#define SB_REG_FRQ         (0x07)      // poll freq cfg
+#define SB_REG_RST         (0x08)      // *reset
+#define SB_REG_FIF         (0x09)      // *fifo
+#define SB_REG_BK2         (0x0A)      // *keyboard backlight
+#define SB_REG_BAT         (0x0B)      // *battery
+#define SB_REG_OFF         (0x0E)      // *power off
 
 // Function prototypes
 bool sb_available();
@@ -36,8 +37,12 @@ void sb_read(uint8_t *dst, size_t len);
 void sb_init();
 
 uint16_t sb_read_keyboard(void);
+uint16_t sb_read_keyboard_state(void);
 uint8_t sb_read_battery(void);
 uint8_t sb_read_lcd_backlight(void);
 void sb_write_lcd_backlight(uint8_t brightness);
 uint8_t sb_read_keyboard_backlight(void);
 void sb_write_keyboard_backlight(uint8_t brightness);
+bool sb_is_power_off_supported(void);
+void sb_write_power_off_delay(uint8_t delay_seconds);
+void sb_reset(uint8_t delay_seconds);

--- a/main.c
+++ b/main.c
@@ -9,6 +9,8 @@
 
 #include "commands.h"
 
+bool power_off_requested = false;
+
 void set_onboard_led(uint8_t led)
 {
     led_set(led & 0x01);
@@ -88,6 +90,7 @@ int main()
         
         run_command(buffer); // Call the command handler
 
-        printf("\033[q\nReady.\n"); // Turn off the LED and prompt for input again
+        printf("\033[q\nReady. %s\n", power_off_requested ? "(power off requested)" : ""); // Turn off the LED and prompt for input again
+        power_off_requested = false;
     }
 }

--- a/tests.c
+++ b/tests.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "pico/rand.h"
 #include "drivers/audio.h"
 #include "drivers/fat32.h"
 #include "drivers/lcd.h"
@@ -418,6 +419,25 @@ void displaytest()
     printf("Average characters per second: %.0f\n", chars_per_second);
     printf("Characters displayed: %d\n", chars);
     printf("Average displayed cps: %.0f\n", displayed_per_second);
+}
+
+void lcdtest()
+{
+    printf("\033[2J\033[HRunning LCD driver test...\n");
+    char *hi = "Hello!";
+
+    for(int i=0; i < 100; i++)
+    {
+        if (user_interrupt)
+        {
+            printf("\nUser interrupt detected.\nStopping LCD test.\n");
+            return;
+        }
+        int column = get_rand_32() % (columns - 6);
+        int row = get_rand_32() % 32;
+        lcd_putstr(column, row, hi);
+        sleep_ms(100);
+    }
 }
 
 void keyboardtest()
@@ -1218,8 +1238,9 @@ void fat32test()
 const test_t tests[] = {
     {"audio", audiotest, "Audio Driver Test"},
     {"display", displaytest, "Display Driver Test"},
-    {"keyboard", keyboardtest, "Keyboard Driver Test"},
     {"fat32", fat32test, "FAT32 File System Test"},
+    {"keyboard", keyboardtest, "Keyboard Driver Test"},
+    {"lcd", lcdtest, "LCD Driver Test"},
     {NULL, NULL, NULL} // End marker
 };
 


### PR DESCRIPTION
This pull request introduces several new features and improvements to device control, display functionality, and documentation. Notably, it adds support for device reset and power management, enhances the LCD driver with string rendering capabilities, and updates the documentation to reflect these changes.

**Device Control and Power Management Enhancements:**

- Added a new `reset` command and corresponding `reset()` function in `commands.c` to allow resetting the device via command line, utilizing the new `sb_reset()` southbridge function. (`[[1]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR42)`, `[[2]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR445-R451)`, `[[3]](diffhunk://#diff-aac3b987edcf7e4e6dc15cef5d35d386a78bb034a138bfc56337c813dbc3c909R27)`, `[[4]](diffhunk://#diff-faed1773d469108ec71433c3cf7c77c2e440e6aba821f9ce4d051c266cc4f674R40-R48)`, `[[5]](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dR57-R77)`)
- Implemented new power management functions in the southbridge driver: `sb_is_power_off_supported()`, `sb_write_power_off_delay()`, and `sb_reset()`, along with their documentation. (`[[1]](diffhunk://#diff-b7a23d592a9a8191cad3562fbe64b7400e4e21fdd4c2ac4007267c598051a6ecR143-R197)`, `[[2]](diffhunk://#diff-faed1773d469108ec71433c3cf7c77c2e440e6aba821f9ce4d051c266cc4f674R40-R48)`, `[[3]](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dR57-R77)`)
- Added handling for the `KEY_POWER` key, including a new `KEY_POWER` definition and logic to set a `power_off_requested` flag when pressed. (`[[1]](diffhunk://#diff-ec1270a1ed9eb12f9aaf308fd85ae0f47312b0cd48293474dbf46f8bac130e91R50)`, `[[2]](diffhunk://#diff-a1bff1045ffca1444a87bc7b81458df460828aed1a18e30f1565c7451640949bR24)`, `[[3]](diffhunk://#diff-a1bff1045ffca1444a87bc7b81458df460828aed1a18e30f1565c7451640949bR78-R81)`, `[[4]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR12-R13)`, `[[5]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL91-R94)`)

**Display and LCD Driver Improvements:**

- Introduced the `lcd_putstr()` function to render strings on the display, with supporting buffer allocation and header declaration. Also added a new LCD test (`lcdtest`) to `tests.c` to exercise this functionality. (`[[1]](diffhunk://#diff-56ed0497651114512d60c2d8e2e9f16c433c41387285bb1d1161f9acb55e41caR40)`, `[[2]](diffhunk://#diff-56ed0497651114512d60c2d8e2e9f16c433c41387285bb1d1161f9acb55e41caR462-R536)`, `[[3]](diffhunk://#diff-c144626d8d250fd91711f9d84fd17678c6a7a25977a1d2ce06c9be27ce71e7ecR113)`, `[[4]](diffhunk://#diff-8b67504b673336e66ef0b851a7c85457d7b65f1b6779aadceb094a8ce16d61eeR424-R442)`, `[[5]](diffhunk://#diff-8b67504b673336e66ef0b851a7c85457d7b65f1b6779aadceb094a8ce16d61eeL1221-R1243)`)
- Updated documentation (`docs/lcd.md`) to describe the new `lcd_putstr()` API. (`[docs/lcd.mdR200-R212](diffhunk://#diff-f1f583d47e0caf8abc14a974611baea467f6fddb73d799677c1bfa7bc1d19163R200-R212)`)

**Southbridge and Documentation Updates:**

- Added and documented `sb_read_keyboard_state()` to read the keyboard's current state, including FIFO characters and Caps Lock status. (`[[1]](diffhunk://#diff-b7a23d592a9a8191cad3562fbe64b7400e4e21fdd4c2ac4007267c598051a6ecR66-R78)`, `[[2]](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dR11-R15)`)
- Updated southbridge register definitions and reorganized code for clarity and maintainability. (`[drivers/southbridge.hL18-R29](diffhunk://#diff-faed1773d469108ec71433c3cf7c77c2e440e6aba821f9ce4d051c266cc4f674L18-R29)`)

**Build and Dependency Updates:**

- Incremented the program version to 0.10 in `CMakeLists.txt` and added `pico_rand` to the list of linked libraries. (`[[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL72-R72)`, `[[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR100)`)
- Included `pico/rand.h` in `tests.c` to support random number generation for display testing. (`[tests.cR5](diffhunk://#diff-8b67504b673336e66ef0b851a7c85457d7b65f1b6779aadceb094a8ce16d61eeR5)`)

These changes collectively improve device usability, power management, and display capabilities, while keeping the documentation and build configuration up to date.