### PR TITLE
Write reg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
-set(PICO_BOARD pico2_w CACHE STRING "Board type")
+set(PICO_BOARD pico CACHE STRING "Board type")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(picocalc-text-starter
         )
 
 pico_set_program_name(picocalc-text-starter "picocalc-text-starter")
-pico_set_program_version(picocalc-text-starter "0.9")
+pico_set_program_version(picocalc-text-starter "0.10")
 
 
 # Generate PIO header
@@ -97,6 +97,7 @@ target_link_libraries(picocalc-text-starter
         pico_printf
         pico_float
         pico_status_led
+        pico_rand
         hardware_gpio
         hardware_i2c
         hardware_spi

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This starter includes drivers for:
 - Keyboard
 - Serial port
 - SD Card (FAT32 file system only)
-- Southbridge functions (keyboard, battery, backlights)
+- Southbridge functions (keyboard, battery, backlights, power)
 
 See below for more information on integration with the C standard library and the REPL provided to demonstrate the drivers.
 
@@ -116,7 +116,7 @@ The main entry point for this starter is a simple REPL to run demos and tests of
 
 These commands provide examples of how to use the drivers:
 
-- **backlight** - Displays the backlight values for the display and keyboard
+- **backlight** - Displays or sets the backlight values for the display and keyboard
 - **battery** – Displays the battery level and status (graphically)
 - **beep** – Play a simple beep sound
 - **box** – Draws a yellow box using special graphics characters
@@ -130,7 +130,9 @@ These commands provide examples of how to use the drivers:
 - **mv** – Move a file or directory
 - **more** – Display the contents of a file
 - **play** – Play a named song (use 'songs' for a list of available songs)
+- **poweroff** – Powers off the device after a delay (requires BIOS 1.4)
 - **pwd** – Displays the current directory
+- **reset** – Resets the device after a delay (requires BIOS 1.4)
 - **rm** – Remove a file
 - **rmdir** – Remove a directory
 - **sdcard** – Provides information about the inserted SD card
@@ -162,6 +164,7 @@ Tests to make sure the hardware and drivers are working correctly.
 - **audio** – Test the audio driver with different notes, distinct left/right separation, melodies bouncing between channels, and harmonious intervals. 
 - **display** – Display driver stress test with scrolling lines of different colours, writing ANSI escape codes and characters as quickly as possible. Note: characters processed includes the processing of escape squences where characters displayed are the number of characters drawn on the display.
 - **keyboard** – Test the keyboard driver by pressing keys and displaying the key codes. Press 'Brk' to exit the test.
+- **lcd** – Basic test of the LCD driver.
 - **fat32** – Test the FAT32 driver with different file operations (create, read, write, delete) and verify the integrity of the file system.
 
 

--- a/commands.c
+++ b/commands.c
@@ -39,6 +39,7 @@ static const command_t commands[] = {
     {"more", sd_more, "Page through a file"},
     {"play", play, "Play a song"},
     {"pwd", sd_pwd, "Print working directory"},
+    {"reset", reset, "Reset the device"},
     {"rm", sd_rm, "Remove a file"},
     {"rmdir", sd_rmdir, "Remove a directory"},
     {"sdcard", sd_status, "Show SD card status"},
@@ -441,6 +442,13 @@ void width_set(const char *width)
 
     printf("Terminal width set to %s characters.\n", width);
 }
+
+void reset()
+{
+    printf("Resetting the device in one second...\n");
+    sb_reset(1);
+}
+
 //
 // SD Card Commands
 //

--- a/commands.c
+++ b/commands.c
@@ -24,7 +24,7 @@ uint8_t columns = 40;
 
 // Command table - map of command names to functions
 static const command_t commands[] = {
-    {"backlight", backlight, "Show the backlight levels"},
+    {"backlight", backlight, "Show/set the backlight"},
     {"battery", battery, "Show the battery level"},
     {"beep", beep, "Play a simple beep sound"},
     {"box", box, "Draw a box on the screen"},
@@ -38,6 +38,7 @@ static const command_t commands[] = {
     {"mv", sd_mv, "Move or rename a file/directory"},
     {"more", sd_more, "Page through a file"},
     {"play", play, "Play a song"},
+    {"poweroff", power_off, "Power off the device"},
     {"pwd", sd_pwd, "Print working directory"},
     {"reset", reset, "Reset the device"},
     {"rm", sd_rm, "Remove a file"},
@@ -50,7 +51,6 @@ static const command_t commands[] = {
     {"help", show_command_library, "Show this help message"},
     {NULL, NULL, NULL} // Sentinel to mark end of array
 };
-
 
 char *strechr(const char *s, int c)
 {
@@ -86,7 +86,7 @@ char *condense(char *s)
             *dst++ = *src++;
         }
         else
-        { 
+        {
             src++;
             if (*src == '\0')
             {
@@ -244,6 +244,18 @@ void run_command(const char *command)
             {
                 width_set(condense(cmd_args[1]));
             }
+            else if (strcmp(cmd_args[0], "poweroff") == 0 && cmd_args[1] != NULL)
+            {
+                power_off_set(condense(cmd_args[1]));
+            }
+            else if (strcmp(cmd_args[0], "reset") == 0 && cmd_args[1] != NULL)
+            {
+                reset_set(condense(cmd_args[1]));
+            }
+            else if (strcmp(cmd_args[0], "backlight") == 0 && cmd_args[1] != NULL && cmd_args[2] != NULL)
+            {
+                backlight_set(condense(cmd_args[1]), condense(cmd_args[2]));
+            }
             else
             {
                 commands[i].function(); // Call the command function
@@ -277,6 +289,27 @@ void backlight()
 
     printf("LCD BackLight: %.0f%%\n", lcd_backlight / 2.55);           // Convert to percentage
     printf("Keyboard BackLight: %.0f%%\n", keyboard_backlight / 2.55); // Convert to percentage
+}
+
+void backlight_set(const char *display_level, const char *keyboard_level)
+{
+    int lcd_level = atoi(display_level);
+    int key_level = atoi(keyboard_level);
+
+    if (lcd_level < 0 || lcd_level > 100 || key_level < 0 || key_level > 100)
+    {
+        printf("Error: Invalid backlight level. Please enter values between 0 and 100.\n");
+        return;
+    }
+
+    uint8_t lcd_backlight = (uint8_t)(lcd_level * 2.55);
+    uint8_t keyboard_backlight = (uint8_t)(key_level * 2.55);
+
+    uint8_t lcd_result = sb_write_lcd_backlight(lcd_backlight);
+    uint8_t keyboard_result = sb_write_keyboard_backlight(keyboard_backlight);
+
+    printf("LCD BackLight set to: %d, claims %d\n", lcd_backlight, lcd_result);
+    printf("Keyboard BackLight set to: %d, claims %d\n", keyboard_backlight, keyboard_result);
 }
 
 void battery()
@@ -443,10 +476,45 @@ void width_set(const char *width)
     printf("Terminal width set to %s characters.\n", width);
 }
 
+void power_off(void)
+{
+    printf("Error: No delay specified.\n");
+    printf("Usage: poweroff <seconds>\n");
+    printf("Example: poweroff 10\n");
+    printf("Set the poweroff delay.\n");
+}
+
+void power_off_set(const char *seconds)
+{
+    if (sb_is_power_off_supported())
+    {
+        int delay = atoi(seconds);
+        printf("Poweroff delay set to %d seconds.\n", delay);
+        sb_write_power_off_delay(delay);
+    }
+    else
+    {
+        printf("Poweroff not supported on this device.\n");
+    }
+}
+
 void reset()
 {
     printf("Resetting the device in one second...\n");
     sb_reset(1);
+}
+
+void reset_set(const char *seconds)
+{
+    int delay = atoi(seconds);
+    if (delay < 0 || delay > 255)
+    {
+        printf("Error: Invalid delay '%s'.\n", seconds);
+        printf("Delay must be between 0 and 255 seconds.\n");
+        return;
+    }
+    printf("Resetting the device in %d seconds...\n", delay);
+    sb_reset((uint8_t)delay);
 }
 
 //

--- a/commands.h
+++ b/commands.h
@@ -24,6 +24,7 @@ void show_command_library(void);
 void test(void);
 void width(void);
 void width_set(const char *width_str);
+void reset();
 
 // SD card commands
 void sd_pwd(void);

--- a/commands.h
+++ b/commands.h
@@ -11,6 +11,7 @@ extern uint8_t columns; // Global variable for terminal width
 
 // Forward declarations
 void backlight(void);
+void backlight_set(const char *display_level, const char *keyboard_level);
 void battery(void);
 void beep(void);
 void box(void);
@@ -24,7 +25,10 @@ void show_command_library(void);
 void test(void);
 void width(void);
 void width_set(const char *width_str);
+void power_off(void);
+void power_off_set(const char *seconds);
 void reset();
+void reset_set(const char *seconds);
 
 // SD card commands
 void sd_pwd(void);

--- a/docs/lcd.md
+++ b/docs/lcd.md
@@ -197,6 +197,19 @@ Draws a glyph at a location on the display.
 - c – glygh to draw (font offset)
 
 
+## lcd_putstr
+
+`void lcd_putstr(uint8_t column, uint8_t row, const char *s)`
+
+Draws a string of glyphs at a location on the display.
+
+### Parameters
+
+- column - horizontal location to draw
+- row – vertical location to draw
+- s – a pointer to the string of glyphs to draw (font offsets)
+
+
 ## lcd_move_cursor
 
 `void lcd_move_cursor(uint8_t column, uint8_t row)`

--- a/docs/southbridge.md
+++ b/docs/southbridge.md
@@ -8,6 +8,11 @@ The southbridge is the MPU (STM32F103R8T6) on the mainboard of the PicoCalc. Thi
 
 Read a key status and code from the keyboard as a 16-bit half-word. The upper byte is the key status, the lower byte is the key code. 
 
+## sb_read_keyboard_state
+
+`uint16_t sb_read_keyboard_state(void)`
+
+Read the current state of the keyboard. The value is the number of characters waiting in the FIFO. If bit 5 is set, it indicates that the CapsLK is set.
 
 ## sb_read_battery
 
@@ -49,3 +54,24 @@ Sets the keyboard backlight brightness.
 ### Parameters
 
 - brightness – a value between 0 (dark) and 255 (bright)
+
+
+## sb_is_power_off_supported
+
+`bool sb_is_power_off_supported(void)`
+
+Returns true if power off is supported, false otherwise.
+
+
+## sb_write_power_off_delay
+
+`void sb_write_power_off_delay(uint8_t delay_seconds)`
+
+Sets a power off delay with the power management unit. Not sure what this does.
+
+
+## sb_reset
+
+`void sb_reset(uint8_t delay_seconds)`
+
+Reset the PicoCalc after a delay.

--- a/docs/southbridge.md
+++ b/docs/southbridge.md
@@ -29,9 +29,9 @@ Read the current LCD Display backlight brightness, 0 (dark) to 255 (bright).
 
 ## sb_write_lcd_backlight
 
-`void sb_write_lcd_backlight(uint8_t brightness)`
+`uint8_t sb_write_lcd_backlight(uint8_t brightness)`
 
-Sets the LCD Display backlight brightness.
+Sets the LCD Display backlight brightness and returns the value that the southbridge reports.
 
 ### Parameters
 
@@ -47,9 +47,9 @@ Reads the current keyboard backlight brightness, 0 (dark) to 255 (bright).
 
 ## sb_write_keyboard_backlight
 
-`void sb_write_keyboard_backlight(uint8_t brightness)`
+`uint8_t sb_write_keyboard_backlight(uint8_t brightness)`
 
-Sets the keyboard backlight brightness.
+Sets the keyboard backlight brightness and returns the value that the southbridge reports.
 
 ### Parameters
 
@@ -60,18 +60,18 @@ Sets the keyboard backlight brightness.
 
 `bool sb_is_power_off_supported(void)`
 
-Returns true if power off is supported, false otherwise.
+Returns true if power off is supported, false otherwise. This function will return true if BIOS 1.4 is present.
 
 
 ## sb_write_power_off_delay
 
 `void sb_write_power_off_delay(uint8_t delay_seconds)`
 
-Sets a power off delay with the power management unit. Not sure what this does.
+Powers off the PicoCalc after the specified delay. Requires BIOS 1.4.
 
 
 ## sb_reset
 
 `void sb_reset(uint8_t delay_seconds)`
 
-Reset the PicoCalc after a delay.
+Reset the PicoCalc after a delay. Requires BIOS 1.4.

--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -21,6 +21,7 @@
 #include "southbridge.h"
 
 extern volatile bool user_interrupt;
+extern volatile bool power_off_requested;
 keyboard_key_available_callback_t keyboard_key_available_callback = NULL;
 
 // Modifier key states
@@ -73,6 +74,10 @@ static bool on_keyboard_timer(repeating_timer_t *rt)
                 else if (key_code == KEY_BREAK)
                 {
                     user_interrupt = true; // set user interrupt flag
+                }
+                else if (key_code == KEY_POWER)
+                {
+                    power_off_requested = true; // set power off requested flag
                 }
                 else
                 {

--- a/drivers/keyboard.h
+++ b/drivers/keyboard.h
@@ -47,6 +47,7 @@
 #define KEY_F9              (0x89)
 #define KEY_F10             (0x90)
 
+#define KEY_POWER           (0x91)
 
 // Keyboard type-ahead buffer
 #define KBD_BUFFER_SIZE     (32)

--- a/drivers/lcd.h
+++ b/drivers/lcd.h
@@ -110,6 +110,7 @@ void lcd_scroll_down(void);
 
 // Character and cursor functions
 void lcd_putc(uint8_t column, uint8_t row, uint8_t c);
+void lcd_putstr(uint8_t column, uint8_t row, const char *str);
 void lcd_move_cursor(uint8_t x, uint8_t y);
 void lcd_draw_cursor(void);
 void lcd_erase_cursor(void);

--- a/drivers/southbridge.c
+++ b/drivers/southbridge.c
@@ -104,15 +104,18 @@ uint8_t sb_read_lcd_backlight()
 }
 
 // Write the LCD backlight level
-void sb_write_lcd_backlight(uint8_t brightness)
+uint8_t sb_write_lcd_backlight(uint8_t brightness)
 {
     uint8_t buffer[2];
 
     sb_acquire();
-    buffer[0] = SB_REG_BKL;
+    buffer[0] = SB_REG_BKL | SB_WRITE;
     buffer[1] = brightness;
     sb_write(buffer, 2);
+    sb_read(buffer, 2);
     sb_release();
+
+    return buffer[1];
 }
 
 // Read the keyboard backlight level
@@ -130,15 +133,18 @@ uint8_t sb_read_keyboard_backlight()
 }
 
 // Write the keyboard backlight level
-void sb_write_keyboard_backlight(uint8_t brightness)
+uint8_t sb_write_keyboard_backlight(uint8_t brightness)
 {
     uint8_t buffer[2];
 
     sb_acquire();
-    buffer[0] = SB_REG_BK2;
+    buffer[0] = SB_REG_BK2 | SB_WRITE;
     buffer[1] = brightness;
     sb_write(buffer, 2);
+    sb_read(buffer, 2);
     sb_release();
+
+    return buffer[1];
 }
 
 bool sb_is_power_off_supported()
@@ -159,7 +165,7 @@ void sb_write_power_off_delay(uint8_t delay_seconds)
     uint8_t buffer[2];
 
     sb_acquire();
-    buffer[0] = SB_REG_OFF;
+    buffer[0] = SB_REG_OFF | SB_WRITE;
     buffer[1] = delay_seconds;
     sb_write(buffer, 2);
     sb_release();
@@ -170,9 +176,10 @@ void sb_reset(uint8_t delay_seconds)
     uint8_t buffer[2];
 
     sb_acquire();
-    buffer[0] = SB_REG_RST;
+    buffer[0] = SB_REG_RST | SB_WRITE;
     buffer[1] = delay_seconds;
     sb_write(buffer, 2);
+    sb_read(buffer, 2); // read back to ensure command is sent
     sb_release();
 }
 

--- a/drivers/southbridge.h
+++ b/drivers/southbridge.h
@@ -28,6 +28,8 @@
 #define SB_REG_BAT         (0x0B)      // *battery
 #define SB_REG_OFF         (0x0E)      // *power off
 
+#define SB_WRITE           (0x80)      // write to register
+
 // Function prototypes
 bool sb_available();
 void sb_acquire();
@@ -40,9 +42,9 @@ uint16_t sb_read_keyboard(void);
 uint16_t sb_read_keyboard_state(void);
 uint8_t sb_read_battery(void);
 uint8_t sb_read_lcd_backlight(void);
-void sb_write_lcd_backlight(uint8_t brightness);
+uint8_t sb_write_lcd_backlight(uint8_t brightness);
 uint8_t sb_read_keyboard_backlight(void);
-void sb_write_keyboard_backlight(uint8_t brightness);
+uint8_t sb_write_keyboard_backlight(uint8_t brightness);
 bool sb_is_power_off_supported(void);
 void sb_write_power_off_delay(uint8_t delay_seconds);
 void sb_reset(uint8_t delay_seconds);

--- a/drivers/southbridge.h
+++ b/drivers/southbridge.h
@@ -15,17 +15,18 @@
 
 
 // Keyboard register definitions
-#define SB_REG_VER         (0x01)      // fw version
-#define SB_REG_CFG         (0x02)      // config
-#define SB_REG_INT         (0x03)      // interrupt status
-#define SB_REG_KEY         (0x04)      // key status
-#define SB_REG_BKL         (0x05)      // backlight
-#define SB_REG_DEB         (0x06)      // debounce cfg
-#define SB_REG_FRQ         (0x07)      // poll freq cfg
-#define SB_REG_RST         (0x08)      // reset
-#define SB_REG_FIF         (0x09)      // fifo
-#define SB_REG_BK2         (0x0A)      // keyboard backlight
-#define SB_REG_BAT         (0x0b)      // battery
+//#define SB_REG_VER         (0x01)      // fw version
+//#define SB_REG_CFG         (0x02)      // config
+//#define SB_REG_INT         (0x03)      // interrupt status
+#define SB_REG_KEY         (0x04)      // *key status
+#define SB_REG_BKL         (0x05)      // *backlight
+//#define SB_REG_DEB         (0x06)      // debounce cfg
+//#define SB_REG_FRQ         (0x07)      // poll freq cfg
+#define SB_REG_RST         (0x08)      // *reset
+#define SB_REG_FIF         (0x09)      // *fifo
+#define SB_REG_BK2         (0x0A)      // *keyboard backlight
+#define SB_REG_BAT         (0x0B)      // *battery
+#define SB_REG_OFF         (0x0E)      // *power off
 
 // Function prototypes
 bool sb_available();
@@ -36,8 +37,12 @@ void sb_read(uint8_t *dst, size_t len);
 void sb_init();
 
 uint16_t sb_read_keyboard(void);
+uint16_t sb_read_keyboard_state(void);
 uint8_t sb_read_battery(void);
 uint8_t sb_read_lcd_backlight(void);
 void sb_write_lcd_backlight(uint8_t brightness);
 uint8_t sb_read_keyboard_backlight(void);
 void sb_write_keyboard_backlight(uint8_t brightness);
+bool sb_is_power_off_supported(void);
+void sb_write_power_off_delay(uint8_t delay_seconds);
+void sb_reset(uint8_t delay_seconds);

--- a/main.c
+++ b/main.c
@@ -9,6 +9,8 @@
 
 #include "commands.h"
 
+bool power_off_requested = false;
+
 void set_onboard_led(uint8_t led)
 {
     led_set(led & 0x01);
@@ -88,6 +90,7 @@ int main()
         
         run_command(buffer); // Call the command handler
 
-        printf("\033[q\nReady.\n"); // Turn off the LED and prompt for input again
+        printf("\033[q\nReady. %s\n", power_off_requested ? "(power off requested)" : ""); // Turn off the LED and prompt for input again
+        power_off_requested = false;
     }
 }

--- a/main.c
+++ b/main.c
@@ -68,7 +68,7 @@ int main()
     stdio_init_all();
     picocalc_init(led_init_result == 0 ? set_onboard_led : NULL);
 
-    printf("\033c\033[1m Hello from the PicoCalc Text Starter!\033[0m\n\n");
+    printf("\033c\033[1m\n Hello from the PicoCalc Text Starter!\033[0m\n\n");
     printf("      Contributed to the community\n");
     printf("            by Blair Leduc.\n\n");
     printf("Type \033[4mhelp\033[0m for a list of commands.\n\n");

--- a/tests.c
+++ b/tests.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "pico/rand.h"
 #include "drivers/audio.h"
 #include "drivers/fat32.h"
 #include "drivers/lcd.h"
@@ -418,6 +419,25 @@ void displaytest()
     printf("Average characters per second: %.0f\n", chars_per_second);
     printf("Characters displayed: %d\n", chars);
     printf("Average displayed cps: %.0f\n", displayed_per_second);
+}
+
+void lcdtest()
+{
+    printf("\033[2J\033[HRunning LCD driver test...\n");
+    char *hi = "Hello!";
+
+    for(int i=0; i < 100; i++)
+    {
+        if (user_interrupt)
+        {
+            printf("\nUser interrupt detected.\nStopping LCD test.\n");
+            return;
+        }
+        int column = get_rand_32() % (columns - 6);
+        int row = get_rand_32() % 32;
+        lcd_putstr(column, row, hi);
+        sleep_ms(100);
+    }
 }
 
 void keyboardtest()
@@ -1218,8 +1238,9 @@ void fat32test()
 const test_t tests[] = {
     {"audio", audiotest, "Audio Driver Test"},
     {"display", displaytest, "Display Driver Test"},
-    {"keyboard", keyboardtest, "Keyboard Driver Test"},
     {"fat32", fat32test, "FAT32 File System Test"},
+    {"keyboard", keyboardtest, "Keyboard Driver Test"},
+    {"lcd", lcdtest, "LCD Driver Test"},
     {NULL, NULL, NULL} // End marker
 };
 


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the PicoCalc firmware, focusing on power management commands, improved backlight control, and expanded documentation. It also adds a new LCD driver test, updates the build configuration, and refines the southbridge API. Below are the most important changes grouped by theme:

**Power Management Features:**

- Added new `poweroff` and `reset` commands to the REPL, allowing users to power off or reset the device after a specified delay (requires BIOS 1.4). These commands include both informational and parameterized versions, and appropriate command handler functions were implemented. (`commands.c`, `commands.h`, `README.md`, [[1]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR41-R43) [[2]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR247-R258) [[3]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR478-R519) [[4]](diffhunk://#diff-aac3b987edcf7e4e6dc15cef5d35d386a78bb034a138bfc56337c813dbc3c909R28-R31) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133-R135)
- Introduced southbridge API functions for power management: `sb_is_power_off_supported`, `sb_write_power_off_delay`, and `sb_reset`, with documentation added to `docs/southbridge.md`. (`docs/southbridge.md`, [docs/southbridge.mdL45-R77](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dL45-R77))

**Backlight Control Improvements:**

- Enhanced the `backlight` command to allow setting both display and keyboard backlight levels, with input validation and feedback on the actual values set. (`commands.c`, `commands.h`, `README.md`, [[1]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adL27-R27) [[2]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR247-R258) [[3]](diffhunk://#diff-e21e9114567b81e3651527c6f94e80e0f9d06859b69c488291b74ff9faeb52adR294-R314) [[4]](diffhunk://#diff-aac3b987edcf7e4e6dc15cef5d35d386a78bb034a138bfc56337c813dbc3c909R14) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R119)
- Updated the southbridge API for backlight control to return the value reported by the hardware, and documented the new behavior. (`docs/southbridge.md`, [docs/southbridge.mdL27-R34](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dL27-R34))

**LCD Driver Enhancements:**

- Added a new `lcd_putstr` function to draw strings on the display, with documentation in `docs/lcd.md`. (`drivers/lcd.c`, `drivers/lcd.h`, `docs/lcd.md`, [[1]](diffhunk://#diff-56ed0497651114512d60c2d8e2e9f16c433c41387285bb1d1161f9acb55e41caR462-R536) [[2]](diffhunk://#diff-c144626d8d250fd91711f9d84fd17678c6a7a25977a1d2ce06c9be27ce71e7ecR113) [[3]](diffhunk://#diff-f1f583d47e0caf8abc14a974611baea467f6fddb73d799677c1bfa7bc1d19163R200-R212)
- Introduced a basic LCD driver test command (`lcd`) to the REPL. (`README.md`, [README.mdR167](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R167))

**Keyboard and Southbridge Updates:**

- Added support for the power key (`KEY_POWER`) in the keyboard driver and header, setting a flag when pressed. (`drivers/keyboard.c`, `drivers/keyboard.h`, [[1]](diffhunk://#diff-a1bff1045ffca1444a87bc7b81458df460828aed1a18e30f1565c7451640949bR24) [[2]](diffhunk://#diff-a1bff1045ffca1444a87bc7b81458df460828aed1a18e30f1565c7451640949bR78-R81) [[3]](diffhunk://#diff-ec1270a1ed9eb12f9aaf308fd85ae0f47312b0cd48293474dbf46f8bac130e91R50)
- Added a new `sb_read_keyboard_state` function to the southbridge driver and documented its usage. (`drivers/southbridge.c`, `docs/southbridge.md`, [[1]](diffhunk://#diff-b7a23d592a9a8191cad3562fbe64b7400e4e21fdd4c2ac4007267c598051a6ecR66-R78) [[2]](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dR11-R15)

**Build and Documentation Updates:**

- Changed the default board type in `CMakeLists.txt` from `pico2_w` to `pico`, updated the program version to `0.10`, and linked the `pico_rand` library. (`CMakeLists.txt`, [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL26-R26) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL72-R72) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR100)
- Clarified and expanded documentation for southbridge functions and REPL commands in `README.md` and `docs/southbridge.md`. (`README.md`, `docs/southbridge.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18) [[2]](diffhunk://#diff-6b569f221ab3a9c9a06f2b0579176e2669f4f871a1fbfadd2bdf0bcc45bcf17dR11-R15)

These changes collectively improve the usability, feature set, and maintainability of the firmware, especially with regard to power management and user feedback.