### PR TITLE
Add fat32_rename function and update lcd_blit function signature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(picocalc-text-starter
         )
 
 pico_set_program_name(picocalc-text-starter "picocalc-text-starter")
-pico_set_program_version(picocalc-text-starter "0.12")
+pico_set_program_version(picocalc-text-starter "0.13")
 
 
 # Generate PIO header

--- a/docs/fat32.md
+++ b/docs/fat32.md
@@ -213,6 +213,18 @@ Returns FAT32_OK if successful, otherwise an error code is returned.
 - path – the path to the file to delete
 
 
+## fat32_rename
+
+`fat32_error_t fat32_rename(const char *old_path, const char *new_path)`
+
+Renames or moves a file or directory.
+
+### Parameters
+
+- old_path – the current path of the file or directory
+- new_path – the new path for the file or directory
+
+
 ## fat32_set_current_dir
 
 `fat32_error_t fat32_set_current_dir(const char *path)`

--- a/drivers/display.h
+++ b/drivers/display.h
@@ -41,7 +41,7 @@
 #define WHITE_PHOSPHOR  RGB(216, 240, 255)  // white phosphor
 #define GREEN_PHOSPHOR  RGB(51, 255, 102)   // green phosphor
 #define AMBER_PHOSPHOR  RGB(255, 255, 51)   // amber phosphor
-#define FOREGROUND      WHITE_PHOSPHOR      // default foreground colour
+#define FOREGROUND      RGB(255, 255, 255)  // default foreground colour
 #define BACKGROUND      RGB(0, 0, 0)        // default background colour
 #define BRIGHT          RGB(255, 255, 255)  // white
 #define DIM             RGB(128, 128, 128)  // dim grey

--- a/drivers/lcd.c
+++ b/drivers/lcd.c
@@ -230,7 +230,7 @@ static void lcd_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
 //  red component in the upper 5 bits, the green component in the middle 6 bits, and the
 //  blue component in the lower 5 bits.
 
-void lcd_blit(uint16_t *pixels, uint16_t x, uint16_t y, uint16_t width, uint16_t height)
+void lcd_blit(const uint16_t *pixels, uint16_t x, uint16_t y, uint16_t width, uint16_t height)
 {
     lcd_disable_interrupts();
     if (y >= lcd_scroll_top && y < HEIGHT - lcd_scroll_bottom)

--- a/drivers/lcd.h
+++ b/drivers/lcd.h
@@ -94,7 +94,7 @@ void lcd_write16_data(uint8_t len, ...);
 void lcd_write16_buf(const uint16_t *buffer, size_t len);
 
 // Display window and drawing functions
-void lcd_blit(uint16_t *pixels, uint16_t x, uint16_t y, uint16_t width, uint16_t height);
+void lcd_blit(const uint16_t *pixels, uint16_t x, uint16_t y, uint16_t width, uint16_t height);
 void lcd_solid_rectangle(uint16_t colour, uint16_t x, uint16_t y, uint16_t width, uint16_t height);
 
 // Scrolling functions


### PR DESCRIPTION
This pull request introduces a new API function for renaming files or directories in the FAT32 documentation, updates the default foreground color for display drivers, and improves type safety for the `lcd_blit` function by making its pixel buffer parameter `const`. These changes enhance the documentation, display appearance, and code reliability.

**Documentation improvements:**
* Added documentation for the new `fat32_rename` API, which allows renaming or moving files and directories in FAT32.

**Display driver updates:**
* Changed the default `FOREGROUND` color in `display.h` to pure white (`RGB(255, 255, 255)`), instead of the previous white phosphor value, for more consistent display output.

**Code safety and correctness:**
* Updated the `lcd_blit` function signature in both `lcd.c` and `lcd.h` to accept a `const uint16_t *pixels` buffer, ensuring the pixel data is not modified during blitting. [[1]](diffhunk://#diff-56ed0497651114512d60c2d8e2e9f16c433c41387285bb1d1161f9acb55e41caL233-R233) [[2]](diffhunk://#diff-c144626d8d250fd91711f9d84fd17678c6a7a25977a1d2ce06c9be27ce71e7ecL97-R97)